### PR TITLE
remove static from favicon paths

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,10 +14,10 @@
       {% if config.extra.favicon %}
         <meta name="test">
         <link rel="apple-touch-icon" sizes="180x180" href="{{
-        get_url(path='static/apple-touch-icon.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ get_url(path="static/favicon-32x32.png") }}">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ get_url(path="static/favicon-16x16.png") }}">
-        <link rel="manifest" href="{{ get_url(path="static/site.webmanifest") }}">
+        get_url(path='/apple-touch-icon.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ get_url(path="/favicon-32x32.png") }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ get_url(path="/favicon-16x16.png") }}">
+        <link rel="manifest" href="{{ get_url(path="/site.webmanifest") }}">
       {% endif %}
 
       {% if config.generate_feed %}


### PR DESCRIPTION
We don't need static here as things in /static are copied over to website root